### PR TITLE
Allow extension of order value accessor

### DIFF
--- a/src/Pagination/Accessor/DateTimeValueAccessor.php
+++ b/src/Pagination/Accessor/DateTimeValueAccessor.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+namespace Fazland\ApiPlatformBundle\Pagination\Accessor;
+
+final class DateTimeValueAccessor implements ValueAccessorInterface
+{
+    /**
+     * @var ValueAccessorInterface
+     */
+    private $decorated;
+
+    public function __construct(ValueAccessorInterface $decorated)
+    {
+        $this->decorated = $decorated;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getValue(object $object, string $propertyPath)
+    {
+        $value = $this->decorated->getValue($object, $propertyPath);
+        if ($value instanceof \DateTimeInterface) {
+            $value = $value->getTimestamp();
+        }
+
+        return $value;
+    }
+}

--- a/src/Pagination/Accessor/ValueAccessor.php
+++ b/src/Pagination/Accessor/ValueAccessor.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace Fazland\ApiPlatformBundle\Pagination\Accessor;
+
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
+
+final class ValueAccessor implements ValueAccessorInterface
+{
+    /**
+     * @var PropertyAccessorInterface
+     */
+    private $propertyAccessor;
+
+    public function __construct(PropertyAccessorInterface $propertyAccessor)
+    {
+        $this->propertyAccessor = $propertyAccessor;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getValue(object $object, string $propertyPath)
+    {
+        return $this->propertyAccessor->getValue($object, $propertyPath);
+    }
+}

--- a/src/Pagination/Accessor/ValueAccessorInterface.php
+++ b/src/Pagination/Accessor/ValueAccessorInterface.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+namespace Fazland\ApiPlatformBundle\Pagination\Accessor;
+
+interface ValueAccessorInterface
+{
+    /**
+     * Gets an object value at given path.
+     *
+     * @param object $object
+     * @param string $propertyPath
+     *
+     * @return mixed
+     */
+    public function getValue(object $object, string $propertyPath);
+}

--- a/src/QueryLanguage/Processor/Doctrine/ORM/Processor.php
+++ b/src/QueryLanguage/Processor/Doctrine/ORM/Processor.php
@@ -158,7 +158,7 @@ class Processor
             'order_field' => $this->options['order_field'],
             'continuation_token_field' => $this->options['continuation_token']['field'] ?? null,
             'columns' => $this->columns,
-            'orderable_columns' => \array_keys(\array_filter($this->columns, function (ColumnInterface $column): bool {
+            'orderable_columns' => \array_keys(\array_filter($this->columns, static function (ColumnInterface $column): bool {
                 return $column instanceof Column;
             })),
         ]);

--- a/tests/Pagination/PagerIteratorTest.php
+++ b/tests/Pagination/PagerIteratorTest.php
@@ -125,7 +125,7 @@ class PagerIteratorTest extends TestCase
         );
 
         self::assertEquals(
-            '=OWM1ZjZmZjctYjI4Zi00OGZiLWJhNDctOGJjYzNiMjM1YmVk_1_1ak2bqf', (string) $pager->getNextPageToken()
+            '=OWM1ZjZmZjctYjI4Zi00OGZiLWJhNDctOGJjYzNiMjM1YmVk_1_68lkk0', (string) $pager->getNextPageToken()
         );
     }
 
@@ -163,7 +163,7 @@ class PagerIteratorTest extends TestCase
         $pager->setPageSize(3);
 
         $request = $this->prophesize(Request::class);
-        $request->query = new ParameterBag(['continue' => '=OWM1ZjZmZjctYjI4Zi00OGZiLWJhNDctOGJjYzNiMjM1YmVk_1_1ak2bqf']);
+        $request->query = new ParameterBag(['continue' => '=OWM1ZjZmZjctYjI4Zi00OGZiLWJhNDctOGJjYzNiMjM1YmVk_1_68lkk0']);
 
         $pager->setToken(PageToken::fromRequest($request->reveal()));
 
@@ -177,7 +177,7 @@ class PagerIteratorTest extends TestCase
         );
 
         self::assertEquals(
-            '=ZWFkZDc0NzAtOTVmNS00N2U4LThlNzQtMDgzZDQ1YzMwN2Y2_1_rb4ort', (string) $pager->getNextPageToken()
+            '=ZWFkZDc0NzAtOTVmNS00N2U4LThlNzQtMDgzZDQ1YzMwN2Y2_1_aa6ezc', (string) $pager->getNextPageToken()
         );
     }
 


### PR DESCRIPTION
When dealing with complex objects (with nested objects as properties) a value conversion is needed when calculating the page token.

This PR aims to give an extension point for custom order value extraction: a `ValueAccessorInterface` could be implemented and the original access could be easily decorated to retain the original behavior as fallback of a custom evaluation. 