### PR TITLE
AQL: add dbal sql processor

### DIFF
--- a/src/Pagination/Doctrine/DBAL/PagerIterator.php
+++ b/src/Pagination/Doctrine/DBAL/PagerIterator.php
@@ -1,0 +1,108 @@
+<?php declare(strict_types=1);
+
+namespace Fazland\ApiPlatformBundle\Pagination\Doctrine\DBAL;
+
+use Doctrine\DBAL\FetchMode;
+use Doctrine\DBAL\Query\QueryBuilder;
+use Fazland\ApiPlatformBundle\Pagination\Orderings;
+use Fazland\ApiPlatformBundle\Pagination\PagerIterator as BaseIterator;
+use Fazland\DoctrineExtra\DBAL\IteratorTrait;
+use Fazland\DoctrineExtra\ObjectIteratorInterface;
+
+final class PagerIterator extends BaseIterator implements ObjectIteratorInterface
+{
+    use IteratorTrait;
+
+    public function __construct(QueryBuilder $queryBuilder, $orderBy)
+    {
+        $this->queryBuilder = clone $queryBuilder;
+        $this->totalCount = null;
+
+        $this->apply(null);
+
+        parent::__construct([], $orderBy);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function current()
+    {
+        if (! $this->valid()) {
+            return null;
+        }
+
+        if (null === $this->current) {
+            $this->current = \call_user_func($this->callable, $this->currentElement);
+        }
+
+        return $this->current;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function next(): void
+    {
+        parent::next();
+
+        $this->current = null;
+        $current = parent::current();
+        $this->currentElement = \is_object($current) ? self::toArray($current) : $current;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function rewind(): void
+    {
+        parent::rewind();
+
+        $this->current = null;
+        $current = parent::current();
+        $this->currentElement = \is_object($current) ? self::toArray($current) : $current;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getObjects(): array
+    {
+        $queryBuilder = clone $this->queryBuilder;
+
+        $offset = $queryBuilder->getFirstResult();
+        $queryBuilder->setFirstResult(null);
+
+        $queryBuilder = $this->queryBuilder->getConnection()
+            ->createQueryBuilder()
+            ->select('*')
+            ->from('('.$queryBuilder->getSQL().')', 'x')
+            ->setFirstResult($offset)
+        ;
+
+        foreach ($this->orderBy as $key => [$field, $direction]) {
+            $method = 0 === $key ? 'orderBy' : 'addOrderBy';
+            $queryBuilder->{$method}($field, \strtoupper($direction));
+        }
+
+        $limit = $this->pageSize;
+        if (null !== $this->token) {
+            $timestamp = $this->token->getOrderValue();
+            $limit += $this->token->getOffset();
+            $mainOrder = $this->orderBy[0];
+
+            $direction = Orderings::SORT_ASC === $mainOrder[1] ? '>=' : '<=';
+            $queryBuilder->andWhere($mainOrder[0].' '.$direction.' :timeLimit');
+            $queryBuilder->setParameter('timeLimit', $timestamp);
+        }
+
+        $queryBuilder->setMaxResults($limit);
+
+        return $queryBuilder->execute()->fetchAll(FetchMode::STANDARD_OBJECT);
+    }
+
+    private static function toArray(\stdClass $rowObject): array
+    {
+        return \json_decode(\json_encode($rowObject, JSON_THROW_ON_ERROR, 512), true, 512, JSON_THROW_ON_ERROR);
+    }
+}

--- a/src/QueryLanguage/Processor/Doctrine/AbstractProcessor.php
+++ b/src/QueryLanguage/Processor/Doctrine/AbstractProcessor.php
@@ -7,8 +7,6 @@ use Fazland\ApiPlatformBundle\QueryLanguage\Form\DTO\Query;
 use Fazland\ApiPlatformBundle\QueryLanguage\Form\QueryType;
 use Fazland\ApiPlatformBundle\QueryLanguage\Grammar\Grammar;
 use Fazland\ApiPlatformBundle\QueryLanguage\Processor\ColumnInterface;
-use Fazland\ApiPlatformBundle\QueryLanguage\Processor\Doctrine\ORM\Column as ORMColumn;
-use Fazland\ApiPlatformBundle\QueryLanguage\Processor\Doctrine\PhpCr\Column as PhpCrColumn;
 use Fazland\ApiPlatformBundle\QueryLanguage\Walker\Validation\ValidationWalkerInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
@@ -104,7 +102,7 @@ abstract class AbstractProcessor
             'continuation_token_field' => $this->options['continuation_token']['field'] ?? null,
             'columns' => $this->columns,
             'orderable_columns' => \array_keys(\array_filter($this->columns, static function (ColumnInterface $column): bool {
-                return $column instanceof PhpCrColumn || $column instanceof ORMColumn;
+                return $column instanceof PhpCr\Column || $column instanceof ORM\Column || $column instanceof DBAL\Column;
             })),
         ];
 
@@ -149,7 +147,7 @@ abstract class AbstractProcessor
         $checksumColumn = $this->getIdentifierFieldNames()[0];
         if (isset($this->options['continuation_token']['checksum_field'])) {
             $checksumColumn = $this->options['continuation_token']['checksum_field'];
-            if (! $this->columns[$checksumColumn] instanceof PhpCrColumn && ! $this->columns[$checksumColumn] instanceof ORMColumn) {
+            if (! $this->columns[$checksumColumn] instanceof PhpCr\Column && ! $this->columns[$checksumColumn] instanceof ORM\Column) {
                 throw new \InvalidArgumentException(\sprintf('%s is not a valid field for checksum', $this->options['continuation_token']['checksum_field']));
             }
 

--- a/src/QueryLanguage/Processor/Doctrine/DBAL/Column.php
+++ b/src/QueryLanguage/Processor/Doctrine/DBAL/Column.php
@@ -1,0 +1,75 @@
+<?php declare(strict_types=1);
+
+namespace Fazland\ApiPlatformBundle\QueryLanguage\Processor\Doctrine\DBAL;
+
+use Doctrine\DBAL\Query\QueryBuilder;
+use Doctrine\DBAL\Types\Types;
+use Fazland\ApiPlatformBundle\QueryLanguage\Expression\ExpressionInterface;
+use Fazland\ApiPlatformBundle\QueryLanguage\Processor\ColumnInterface;
+use Fazland\ApiPlatformBundle\QueryLanguage\Walker\DBAL\SqlWalker;
+
+/**
+ * @internal
+ */
+class Column implements ColumnInterface
+{
+    private string $columnType;
+    public string $fieldName;
+    public ?string $tableName;
+
+    /**
+     * @var string|callable|null
+     */
+    public $validationWalker;
+
+    /**
+     * @var string|callable|null
+     */
+    public $customWalker;
+
+    public function __construct(string $fieldName, ?string $tableName = null, string $type = Types::STRING)
+    {
+        $this->fieldName = $fieldName;
+        $this->tableName = $tableName;
+        $this->columnType = $type;
+
+        $this->validationWalker = null;
+        $this->customWalker = null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addCondition($queryBuilder, ExpressionInterface $expression): void
+    {
+        $this->addWhereCondition($queryBuilder, $expression);
+    }
+
+    /**
+     * Adds a simple condition to the query builder.
+     *
+     * @param QueryBuilder        $queryBuilder
+     * @param ExpressionInterface $expression
+     */
+    private function addWhereCondition(QueryBuilder $queryBuilder, ExpressionInterface $expression): void
+    {
+        $walker = $this->customWalker;
+        $fieldName = ($this->tableName ? $this->tableName.'.' : '').$this->fieldName;
+
+        if (null !== $walker) {
+            $walker = \is_string($walker) ? new $walker($queryBuilder, $fieldName) : $walker($queryBuilder, $fieldName, $this->columnType);
+        } else {
+            $walker = new SqlWalker($queryBuilder, $fieldName, $this->columnType);
+        }
+
+        $queryBuilder->andWhere($expression->dispatch($walker));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getValidationWalker()
+    {
+        return $this->validationWalker;
+    }
+}

--- a/src/QueryLanguage/Processor/Doctrine/DBAL/Processor.php
+++ b/src/QueryLanguage/Processor/Doctrine/DBAL/Processor.php
@@ -1,0 +1,160 @@
+<?php declare(strict_types=1);
+
+namespace Fazland\ApiPlatformBundle\QueryLanguage\Processor\Doctrine\DBAL;
+
+use Doctrine\DBAL\Query\QueryBuilder;
+use Fazland\ApiPlatformBundle\Pagination\Doctrine\DBAL\PagerIterator;
+use Fazland\ApiPlatformBundle\QueryLanguage\Expression\OrderExpression;
+use Fazland\ApiPlatformBundle\QueryLanguage\Processor\ColumnInterface;
+use Fazland\ApiPlatformBundle\QueryLanguage\Processor\Doctrine\AbstractProcessor;
+use Fazland\DoctrineExtra\DBAL\RowIterator;
+use Fazland\DoctrineExtra\ObjectIteratorInterface;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class Processor extends AbstractProcessor
+{
+    private QueryBuilder $queryBuilder;
+    private array $identifierFields;
+
+    public function __construct(QueryBuilder $queryBuilder, FormFactoryInterface $formFactory, array $options = [])
+    {
+        parent::__construct($formFactory, $options);
+
+        $this->identifierFields = \array_values($this->options['identifiers']);
+        $this->queryBuilder = $queryBuilder;
+    }
+
+    /**
+     * @param Request $request
+     *
+     * @return ObjectIteratorInterface|FormInterface
+     */
+    public function processRequest(Request $request)
+    {
+        $result = $this->handleRequest($request);
+        if ($result instanceof FormInterface) {
+            return $result;
+        }
+
+        $this->attachToQueryBuilder($result->filters);
+        $pageSize = $this->options['default_page_size'] ?? $result->limit;
+
+        if (null !== $result->skip) {
+            $this->queryBuilder->setFirstResult($result->skip);
+        }
+
+        if (null !== $result->ordering) {
+            if ($this->options['continuation_token']) {
+                $iterator = new PagerIterator($this->queryBuilder, $this->parseOrderings($result->ordering));
+                $iterator->setToken($result->pageToken);
+                if (null !== $pageSize) {
+                    $iterator->setPageSize($pageSize);
+                }
+
+                return $iterator;
+            }
+
+            $sql = $this->queryBuilder->getSQL();
+            $direction = $result->ordering->getDirection();
+            $fieldName = $this->columns[$result->ordering->getField()]->fieldName;
+
+            $this->queryBuilder = $this->queryBuilder->getConnection()
+                ->createQueryBuilder()
+                ->select('*')
+                ->from("($sql)", 'x')
+                ->setFirstResult($result->skip ?? 0)
+                ->orderBy($fieldName, $direction)
+            ;
+        }
+
+        if (null !== $pageSize) {
+            $this->queryBuilder->setMaxResults($pageSize);
+        }
+
+        return new RowIterator($this->queryBuilder);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function createColumn(string $fieldName): ColumnInterface
+    {
+        $tableName = null;
+        if (false !== \strpos($fieldName, '.')) {
+            [$tableName, $fieldName] = \explode('.', $fieldName);
+        }
+
+        return new Column($fieldName, $tableName);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getIdentifierFieldNames(): array
+    {
+        return $this->identifierFields;
+    }
+
+    /**
+     * Parses the ordering expression for continuation token.
+     *
+     * @param OrderExpression $ordering
+     *
+     * @return array
+     */
+    protected function parseOrderings(OrderExpression $ordering): array
+    {
+        $checksumColumn = $this->options['continuation_token']['checksum_field'] ?? $this->getIdentifierFieldNames()[0] ?? null;
+        $column = $this->columns[$ordering->getField()];
+
+        if (null === $checksumColumn) {
+            foreach ($this->columns as $column) {
+                if ($checksumColumn === $column) {
+                    continue;
+                }
+
+                $checksumColumn = $column;
+                break;
+            }
+        }
+
+        $checksumField = $checksumColumn instanceof Column ? $checksumColumn->fieldName : $checksumColumn;
+        $fieldName = $column->fieldName;
+        $direction = $ordering->getDirection();
+
+        return [
+            $fieldName => $direction,
+            $checksumField => 'ASC',
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'identifiers' => [],
+        ]);
+
+        $resolver->setAllowedTypes('identifiers', 'array');
+    }
+
+    /**
+     * Add conditions to query builder.
+     *
+     * @param array $filters
+     */
+    private function attachToQueryBuilder(array $filters): void
+    {
+        $this->queryBuilder->andWhere('1 = 1');
+
+        foreach ($filters as $key => $expr) {
+            $column = $this->columns[$key];
+            $column->addCondition($this->queryBuilder, $expr);
+        }
+    }
+}

--- a/src/QueryLanguage/Walker/DBAL/SqlWalker.php
+++ b/src/QueryLanguage/Walker/DBAL/SqlWalker.php
@@ -1,0 +1,153 @@
+<?php declare(strict_types=1);
+
+namespace Fazland\ApiPlatformBundle\QueryLanguage\Walker\DBAL;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Query\QueryBuilder;
+use Doctrine\DBAL\Types\Types;
+use Fazland\ApiPlatformBundle\QueryLanguage\Expression\ExpressionInterface;
+use Fazland\ApiPlatformBundle\QueryLanguage\Expression\Literal\LiteralExpression;
+use Fazland\ApiPlatformBundle\QueryLanguage\Expression\Literal\NullExpression;
+use Fazland\ApiPlatformBundle\QueryLanguage\Expression\Literal\StringExpression;
+use Fazland\ApiPlatformBundle\QueryLanguage\Expression\ValueExpression;
+use Fazland\ApiPlatformBundle\QueryLanguage\Walker\AbstractWalker;
+
+class SqlWalker extends AbstractWalker
+{
+    private AbstractPlatform $platform;
+    protected QueryBuilder $queryBuilder;
+    private ?string $columnType;
+    private string $fieldName;
+
+    public function __construct(QueryBuilder $queryBuilder, string $field, ?string $columnType = null)
+    {
+        $this->platform = $queryBuilder->getConnection()->getDatabasePlatform();
+        parent::__construct($this->platform->quoteIdentifier($field));
+
+        $this->fieldName = $field;
+        $this->queryBuilder = $queryBuilder;
+        $this->columnType = $columnType;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function walkLiteral(LiteralExpression $expression)
+    {
+        $value = parent::walkLiteral($expression);
+        if ($expression instanceof NullExpression) {
+            return $value;
+        }
+
+        switch ($this->columnType) {
+            case Types::DATETIME_MUTABLE:
+            case Types::DATETIMETZ_MUTABLE:
+                return new \DateTime($value);
+
+            case Types::DATETIME_IMMUTABLE:
+            case Types::DATETIMETZ_IMMUTABLE:
+                return new \DateTimeImmutable($value);
+
+            default:
+                return $value;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function walkComparison(string $operator, ValueExpression $expression)
+    {
+        $field = $this->field;
+        if ($expression instanceof NullExpression) {
+            return $field.' IS NULL';
+        }
+
+        if ('like' === $operator) {
+            $field = $this->platform->getLowerExpression($this->field);
+            $expression = StringExpression::create('%'.\mb_strtolower((string) $expression).'%');
+        }
+
+        $parameterName = $this->generateParameterName();
+        $this->queryBuilder->setParameter($parameterName, $expression->dispatch($this), $this->columnType);
+
+        return $field.' '.$operator.' :'.$parameterName;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function walkAll()
+    {
+        // Do nothing.
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function walkOrder(string $field, string $direction)
+    {
+        return 'ORDER BY '.$this->platform->quoteIdentifier($field).' '.$direction;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function walkNot(ExpressionInterface $expression)
+    {
+        return $this->platform->getNotExpression($expression->dispatch($this));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function walkAnd(array $arguments)
+    {
+        return '('.\implode(' AND ', \array_map(
+            fn (ExpressionInterface $expression) => $expression->dispatch($this),
+            $arguments
+        )).')';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function walkOr(array $arguments)
+    {
+        return '('.\implode(' OR ', \array_map(
+            fn (ExpressionInterface $expression) => $expression->dispatch($this),
+            $arguments
+        )).')';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function walkEntry(string $key, ExpressionInterface $expression)
+    {
+        $walker = new SqlWalker($this->queryBuilder, $this->fieldName.'.'.$key);
+
+        return $expression->dispatch($walker);
+    }
+
+    /**
+     * Generates a unique parameter name for current field.
+     *
+     * @return string
+     */
+    protected function generateParameterName(): string
+    {
+        $params = $this->queryBuilder->getParameters();
+        $underscoreField = \mb_strtolower(
+            \preg_replace('/(?|(?<=[a-z0-9])([A-Z])|(?<=[A-Z]{2})([a-z]))/', '_$1', $this->fieldName)
+        );
+        $parameterName = $origParamName = \preg_replace('/\W+/', '_', $underscoreField);
+
+        $i = 1;
+        while (\array_key_exists($parameterName, $params)) {
+            $parameterName = $origParamName.'_'.$i++;
+        }
+
+        return $parameterName;
+    }
+}

--- a/tests/Pagination/Doctrine/Dbal/PagerIteratorTest.php
+++ b/tests/Pagination/Doctrine/Dbal/PagerIteratorTest.php
@@ -1,0 +1,236 @@
+<?php declare(strict_types=1);
+
+namespace Fazland\ApiPlatformBundle\Tests\Pagination\DBAL;
+
+use Doctrine\DBAL\Cache\ArrayStatement;
+use Doctrine\DBAL\Driver\Statement;
+use Doctrine\DBAL\FetchMode;
+use Doctrine\DBAL\Query\QueryBuilder;
+use Fazland\ApiPlatformBundle\Pagination\Doctrine\DBAL\PagerIterator;
+use Fazland\ApiPlatformBundle\Pagination\PageToken;
+use Fazland\ApiPlatformBundle\Tests\Fixtures\Doctrine\EntityManagerMockTrait;
+use PDO;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\Request;
+
+class PagerIteratorTest extends TestCase
+{
+    use EntityManagerMockTrait;
+
+    private QueryBuilder $queryBuilder;
+    private PagerIterator $iterator;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp(): void
+    {
+        $this->entityManager = null;
+        $this->getEntityManager();
+
+        $this->queryBuilder = $this->connection->createQueryBuilder();
+        $this->queryBuilder
+            ->select('t.id', 't.timestamp')
+            ->from('test_table', 't')
+        ;
+
+        $this->innerConnection->query('')->shouldNotBeCalled();
+
+        $this->iterator = new PagerIterator($this->queryBuilder, ['timestamp', 'id']);
+        $this->iterator->setPageSize(3);
+    }
+
+    public function testPagerShouldGenerateFirstPageWithToken(): void
+    {
+        $this->innerConnection->query('SELECT * FROM (SELECT t.id, t.timestamp FROM test_table t) x ORDER BY timestamp ASC, id ASC LIMIT 3')
+            ->willReturn(new StdObjectStatement([
+                ['id' => 'b4902bde-28d2-4ff9-8971-8bfeb3e943c1', 'timestamp' => '1991-11-24 00:00:00'],
+                ['id' => '191a54d8-990c-4ea7-9a23-0aed29d1fffe', 'timestamp' => '1991-11-24 01:00:00'],
+                ['id' => '9c5f6ff7-b28f-48fb-ba47-8bcc3b235bed', 'timestamp' => '1991-11-24 02:00:00'],
+            ]))
+        ;
+
+        $request = $this->prophesize(Request::class);
+        $request->query = new ParameterBag([]);
+
+        $this->iterator->setToken(PageToken::fromRequest($request->reveal()));
+
+        self::assertEquals([
+            ['id' => 'b4902bde-28d2-4ff9-8971-8bfeb3e943c1', 'timestamp' => '1991-11-24 00:00:00'],
+            ['id' => '191a54d8-990c-4ea7-9a23-0aed29d1fffe', 'timestamp' => '1991-11-24 01:00:00'],
+            ['id' => '9c5f6ff7-b28f-48fb-ba47-8bcc3b235bed', 'timestamp' => '1991-11-24 02:00:00'],
+        ], \iterator_to_array($this->iterator));
+
+        self::assertEquals('=MTk5MS0xMS0yNCAwMjowMDowMA==_1_1jvdwz4', (string) $this->iterator->getNextPageToken());
+    }
+
+    public function testPagerShouldGenerateSecondPageWithTokenAndLastPage(): void
+    {
+        $this->innerConnection->prepare('SELECT * FROM (SELECT t.id, t.timestamp FROM test_table t) x WHERE timestamp >= ? ORDER BY timestamp ASC, id ASC LIMIT 4')
+            ->willReturn($stmt = $this->prophesize(Statement::class))
+        ;
+
+        $stmt->bindValue(1, '1991-11-24 02:00:00', \PDO::PARAM_STR)->willReturn();
+        $stmt->setFetchMode(\PDO::FETCH_ASSOC)->willReturn();
+        $stmt->execute()->willReturn(true);
+        $stmt->closeCursor()->willReturn(true);
+
+        $stmt->fetchAll(\PDO::FETCH_OBJ)
+            ->willReturn([
+                (object) ['id' => '9c5f6ff7-b28f-48fb-ba47-8bcc3b235bed', 'timestamp' => '1991-11-24 02:00:00'],
+                (object) ['id' => 'af6394a4-7344-4fe8-9748-e6c67eba5ade', 'timestamp' => '1991-11-24 03:00:00'],
+                (object) ['id' => '84810e2e-448f-4f58-acb8-4db1381f5de3', 'timestamp' => '1991-11-24 04:00:00'],
+                (object) ['id' => 'eadd7470-95f5-47e8-8e74-083d45c307f6', 'timestamp' => '1991-11-24 05:00:00'],
+            ])
+        ;
+
+        $request = $this->prophesize(Request::class);
+        $request->query = new ParameterBag(['continue' => '=MTk5MS0xMS0yNCAwMjowMDowMA==_1_1jvdwz4']);
+
+        $this->iterator->setToken(PageToken::fromRequest($request->reveal()));
+
+        self::assertEquals([
+            ['id' => 'af6394a4-7344-4fe8-9748-e6c67eba5ade', 'timestamp' => '1991-11-24 03:00:00'],
+            ['id' => '84810e2e-448f-4f58-acb8-4db1381f5de3', 'timestamp' => '1991-11-24 04:00:00'],
+            ['id' => 'eadd7470-95f5-47e8-8e74-083d45c307f6', 'timestamp' => '1991-11-24 05:00:00'],
+        ], \iterator_to_array($this->iterator));
+
+        self::assertEquals('=MTk5MS0xMS0yNCAwNTowMDowMA==_1_cukvcs', (string) $this->iterator->getNextPageToken());
+    }
+
+    public function testOffsetShouldWork(): void
+    {
+        $this->innerConnection->query('SELECT * FROM (SELECT t.id, t.timestamp FROM test_table t) x ORDER BY timestamp ASC, id ASC LIMIT 3')
+            ->willReturn(new StdObjectStatement([
+                ['id' => 'b4902bde-28d2-4ff9-8971-8bfeb3e943c1', 'timestamp' => '1991-11-24 00:00:00'],
+                ['id' => '191a54d8-990c-4ea7-9a23-0aed29d1fffe', 'timestamp' => '1991-11-24 01:00:00'],
+                ['id' => '84810e2e-448f-4f58-acb8-4db1381f5de3', 'timestamp' => '1991-11-24 01:00:00'],
+            ]))
+        ;
+
+        $request = $this->prophesize(Request::class);
+        $request->query = new ParameterBag([]);
+
+        $this->iterator->setToken(PageToken::fromRequest($request->reveal()));
+
+        self::assertEquals([
+            ['id' => 'b4902bde-28d2-4ff9-8971-8bfeb3e943c1', 'timestamp' => '1991-11-24 00:00:00'],
+            ['id' => '191a54d8-990c-4ea7-9a23-0aed29d1fffe', 'timestamp' => '1991-11-24 01:00:00'],
+            ['id' => '84810e2e-448f-4f58-acb8-4db1381f5de3', 'timestamp' => '1991-11-24 01:00:00'],
+        ], \iterator_to_array($this->iterator));
+
+        self::assertEquals(2, $this->iterator->getNextPageToken()->getOffset());
+
+        $request = $this->prophesize(Request::class);
+        $request->query = new ParameterBag(['continue' => '=MTk5MS0xMS0yNCAwMTowMDowMA==_2_hzr9o9']);
+
+        $this->iterator->setToken(PageToken::fromRequest($request->reveal()));
+
+        $this->innerConnection->prepare('SELECT * FROM (SELECT t.id, t.timestamp FROM test_table t) x WHERE timestamp >= ? ORDER BY timestamp ASC, id ASC LIMIT 5')
+            ->willReturn($stmt = $this->prophesize(Statement::class))
+        ;
+
+        $stmt->bindValue(1, '1991-11-24 01:00:00', \PDO::PARAM_STR)->willReturn();
+        $stmt->setFetchMode(\PDO::FETCH_ASSOC)->willReturn();
+        $stmt->execute()->willReturn(true);
+        $stmt->closeCursor()->willReturn(true);
+
+        $stmt->fetchAll(\PDO::FETCH_OBJ)
+            ->willReturn([
+                (object) ['id' => '191a54d8-990c-4ea7-9a23-0aed29d1fffe', 'timestamp' => '1991-11-24 01:00:00'],
+                (object) ['id' => '84810e2e-448f-4f58-acb8-4db1381f5de3', 'timestamp' => '1991-11-24 01:00:00'],
+                (object) ['id' => '9c5f6ff7-b28f-48fb-ba47-8bcc3b235bed', 'timestamp' => '1991-11-24 01:00:00'],
+                (object) ['id' => 'af6394a4-7344-4fe8-9748-e6c67eba5ade', 'timestamp' => '1991-11-24 01:00:00'],
+                (object) ['id' => 'eadd7470-95f5-47e8-8e74-083d45c307f6', 'timestamp' => '1991-11-24 02:00:00'],
+            ])
+        ;
+
+        self::assertEquals([
+            ['id' => '9c5f6ff7-b28f-48fb-ba47-8bcc3b235bed', 'timestamp' => '1991-11-24 01:00:00'],
+            ['id' => 'af6394a4-7344-4fe8-9748-e6c67eba5ade', 'timestamp' => '1991-11-24 01:00:00'],
+            ['id' => 'eadd7470-95f5-47e8-8e74-083d45c307f6', 'timestamp' => '1991-11-24 02:00:00'],
+        ], \iterator_to_array($this->iterator));
+    }
+
+    public function testPagerShouldReturnFirstPageWithTimestampDifference(): void
+    {
+        $this->innerConnection->prepare('SELECT * FROM (SELECT t.id, t.timestamp FROM test_table t) x WHERE timestamp >= ? ORDER BY timestamp ASC, id ASC LIMIT 4')
+            ->willReturn($stmt = $this->prophesize(Statement::class));
+
+        $stmt->bindValue(1, '1991-11-24 02:00:00', \PDO::PARAM_STR)->willReturn();
+        $stmt->setFetchMode(\PDO::FETCH_ASSOC)->willReturn();
+        $stmt->execute()->willReturn(true);
+        $stmt->closeCursor()->willReturn(true);
+
+        $stmt->fetchAll(\PDO::FETCH_OBJ)
+            ->willReturn([
+                (object) ['id' => '9c5f6ff7-b28f-48fb-ba47-8bcc3b235bed', 'timestamp' => '1991-11-24 02:30:00'],
+                (object) ['id' => 'af6394a4-7344-4fe8-9748-e6c67eba5ade', 'timestamp' => '1991-11-24 03:00:00'],
+                (object) ['id' => '84810e2e-448f-4f58-acb8-4db1381f5de3', 'timestamp' => '1991-11-24 04:00:00'],
+                (object) ['id' => 'eadd7470-95f5-47e8-8e74-083d45c307f6', 'timestamp' => '1991-11-24 05:00:00'],
+            ])
+        ;
+
+        $request = $this->prophesize(Request::class);
+        $request->query = new ParameterBag(['continue' => '=MTk5MS0xMS0yNCAwMjowMDowMA==_1_1jvdwz4']); // This token represents a request with the 02:00:00 timestamp
+
+        $this->iterator->setToken(PageToken::fromRequest($request->reveal()));
+
+        self::assertEquals([
+            ['id' => '9c5f6ff7-b28f-48fb-ba47-8bcc3b235bed', 'timestamp' => '1991-11-24 02:30:00'],
+            ['id' => 'af6394a4-7344-4fe8-9748-e6c67eba5ade', 'timestamp' => '1991-11-24 03:00:00'],
+            ['id' => '84810e2e-448f-4f58-acb8-4db1381f5de3', 'timestamp' => '1991-11-24 04:00:00'],
+        ], \iterator_to_array($this->iterator));
+
+        self::assertEquals('=MTk5MS0xMS0yNCAwNDowMDowMA==_1_1xirtcr', (string) $this->iterator->getNextPageToken());
+    }
+
+    public function testPagerShouldReturnFirstPageWithChecksumDifference(): void
+    {
+        $this->innerConnection->prepare('SELECT * FROM (SELECT t.id, t.timestamp FROM test_table t) x WHERE timestamp >= ? ORDER BY timestamp ASC, id ASC LIMIT 4')
+            ->willReturn($stmt = $this->prophesize(Statement::class))
+        ;
+
+        $stmt->bindValue(1, '1991-11-24 02:00:00', \PDO::PARAM_STR)->willReturn();
+        $stmt->setFetchMode(\PDO::FETCH_ASSOC)->willReturn();
+        $stmt->execute()->willReturn(true);
+        $stmt->closeCursor()->willReturn(true);
+
+        $stmt->fetchAll(\PDO::FETCH_OBJ)
+            ->willReturn([
+                (object) ['id' => 'af6394a4-7344-4fe8-9748-e6c67eba5ade', 'timestamp' => '1991-11-24 02:00:00'],
+                (object) ['id' => '9c5f6ff7-b28f-48fb-ba47-8bcc3b235bed', 'timestamp' => '1991-11-24 03:00:00'],
+                (object) ['id' => '191a54d8-990c-4ea7-9a23-0aed29d1fffe', 'timestamp' => '1991-11-24 04:00:00'],
+                (object) ['id' => 'eadd7470-95f5-47e8-8e74-083d45c307f6', 'timestamp' => '1991-11-24 05:00:00'],
+            ])
+        ;
+
+        $request = $this->prophesize(Request::class);
+        $request->query = new ParameterBag(['continue' => '=MTk5MS0xMS0yNCAwMjowMDowMA==_1_1jvdwz4']); // This token represents a request with the 02:00:00 timestamp
+
+        $this->iterator->setToken(PageToken::fromRequest($request->reveal()));
+
+        self::assertEquals([
+            ['id' => 'af6394a4-7344-4fe8-9748-e6c67eba5ade', 'timestamp' => '1991-11-24 02:00:00'],
+            ['id' => '9c5f6ff7-b28f-48fb-ba47-8bcc3b235bed', 'timestamp' => '1991-11-24 03:00:00'],
+            ['id' => '191a54d8-990c-4ea7-9a23-0aed29d1fffe', 'timestamp' => '1991-11-24 04:00:00'],
+        ], \iterator_to_array($this->iterator));
+
+        self::assertEquals('=MTk5MS0xMS0yNCAwNDowMDowMA==_1_7gqxdp', (string) $this->iterator->getNextPageToken());
+    }
+}
+
+class StdObjectStatement extends ArrayStatement
+{
+    public function fetch($fetchMode = null, $cursorOrientation = PDO::FETCH_ORI_NEXT, $cursorOffset = 0)
+    {
+        if (FetchMode::STANDARD_OBJECT === $fetchMode) {
+            $result = parent::fetch(FetchMode::ASSOCIATIVE, $cursorOrientation, $cursorOffset);
+
+            return false !== $result ? \json_decode(\json_encode($result), false) : $result;
+        }
+
+        return parent::fetch($fetchMode, $cursorOrientation, $cursorOffset);
+    }
+}

--- a/tests/QueryLanguage/Processor/Doctrine/DBAL/ProcessorTest.php
+++ b/tests/QueryLanguage/Processor/Doctrine/DBAL/ProcessorTest.php
@@ -1,0 +1,229 @@
+<?php declare(strict_types=1);
+
+namespace Fazland\ApiPlatformBundle\Tests\QueryLanguage\Processor\Doctrine\DBAL;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Fazland\ApiPlatformBundle\Form\Extension\AutoSubmitRequestHandler;
+use Fazland\ApiPlatformBundle\Pagination\PagerIterator;
+use Fazland\ApiPlatformBundle\QueryLanguage\Expression\ExpressionInterface;
+use Fazland\ApiPlatformBundle\QueryLanguage\Processor\ColumnInterface;
+use Fazland\ApiPlatformBundle\QueryLanguage\Processor\Doctrine\DBAL\Processor;
+use Fazland\ApiPlatformBundle\QueryLanguage\Walker\Validation\ValidationWalker;
+use Fazland\ApiPlatformBundle\Tests\Fixtures\Entity\QueryLanguage\FooBar;
+use Fazland\ApiPlatformBundle\Tests\QueryLanguage\Doctrine\ORM\FixturesTrait;
+use Fazland\DoctrineExtra\DBAL\RowIterator;
+use Fazland\DoctrineExtra\ObjectIteratorInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Form\Extension\HttpFoundation\Type\FormTypeHttpFoundationExtension;
+use Symfony\Component\Form\Extension\Validator\ValidatorExtension;
+use Symfony\Component\Form\FormFactoryBuilder;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
+use Symfony\Component\Validator\ValidatorBuilder;
+
+class ProcessorTest extends TestCase
+{
+    use FixturesTrait;
+
+    private Processor $processor;
+
+    protected function setUp(): void
+    {
+        $formFactory = (new FormFactoryBuilder(true))
+            ->addExtension(new ValidatorExtension((new ValidatorBuilder())->getValidator()))
+            ->addTypeExtension(new FormTypeHttpFoundationExtension(new AutoSubmitRequestHandler()))
+            ->getFormFactory();
+
+        $queryBuilder = self::$entityManager->getConnection()->createQueryBuilder();
+        $queryBuilder
+            ->select('id', 'name', 'nameLength')
+            ->from('user', 'u')
+        ;
+
+        $this->processor = new Processor(
+            $queryBuilder,
+            $formFactory,
+            [
+                'order_field' => 'order',
+                'continuation_token' => true,
+                'identifiers' => ['id'],
+            ],
+        );
+    }
+
+    public function testBuiltinColumnWorks(): void
+    {
+        $this->processor->addColumn('name');
+        $itr = $this->processor->processRequest(new Request(['name' => 'goofy']));
+
+        self::assertInstanceOf(ObjectIteratorInterface::class, $itr);
+        $result = \iterator_to_array($itr);
+
+        self::assertCount(1, $result);
+        self::assertEquals('goofy', $result[0]['name']);
+    }
+
+    public function provideParamsForPageSize(): iterable
+    {
+        yield [[]];
+        yield [['order' => '$order(name)']];
+        yield [['order' => '$order(name)', 'continue' => '=YmF6_1_10tf9ny']];
+    }
+
+    /**
+     * @dataProvider provideParamsForPageSize
+     */
+    public function testPageSizeOptionShouldWork(array $params): void
+    {
+        $this->processor->addColumn('name');
+        $this->processor->setDefaultPageSize(3);
+        $itr = $this->processor->processRequest(new Request($params));
+
+        self::assertInstanceOf(ObjectIteratorInterface::class, $itr);
+        $result = \iterator_to_array($itr);
+
+        self::assertCount(3, $result);
+    }
+
+    public function testOrderByDefaultFieldShouldThrowOnInvalidOptions(): void
+    {
+        $this->expectException(InvalidOptionsException::class);
+
+        $formFactory = (new FormFactoryBuilder(true))
+            ->addExtension(new ValidatorExtension((new ValidatorBuilder())->getValidator()))
+            ->addTypeExtension(new FormTypeHttpFoundationExtension(new AutoSubmitRequestHandler()))
+            ->getFormFactory();
+
+        $queryBuilder = self::$entityManager->getConnection()->createQueryBuilder();
+        $queryBuilder
+            ->select('id', 'name', 'nameLength')
+            ->from('user', 'u')
+        ;
+
+        $this->processor = new Processor(
+            $queryBuilder,
+            $formFactory,
+            [
+                'default_order' => '$eq(name)',
+                'order_field' => 'order',
+                'continuation_token' => true,
+                'identifiers' => ['id'],
+            ],
+        );
+
+        $this->processor->addColumn('name');
+        $this->processor->setDefaultPageSize(3);
+        $this->processor->processRequest(new Request([]));
+    }
+
+    public function provideParamsForDefaultOrder(): iterable
+    {
+        yield [true, '$order(name)'];
+        yield [true, 'name'];
+        yield [true, 'name, desc'];
+        yield [false, '$order(nonexistent, asc)'];
+    }
+
+    /**
+     * @dataProvider provideParamsForDefaultOrder
+     */
+    public function testOrderByDefaultFieldShouldWork(bool $valid, string $defaultOrder): void
+    {
+        $formFactory = (new FormFactoryBuilder(true))
+            ->addExtension(new ValidatorExtension((new ValidatorBuilder())->getValidator()))
+            ->addTypeExtension(new FormTypeHttpFoundationExtension(new AutoSubmitRequestHandler()))
+            ->getFormFactory();
+
+        $queryBuilder = self::$entityManager->getConnection()->createQueryBuilder();
+        $queryBuilder
+            ->select('id', 'name', 'nameLength')
+            ->from('user', 'u')
+        ;
+
+        $this->processor = new Processor(
+            $queryBuilder,
+            $formFactory,
+            [
+                'default_order' => $defaultOrder,
+                'order_field' => 'order',
+                'continuation_token' => true,
+                'identifiers' => ['id'],
+            ],
+        );
+
+        $this->processor->addColumn('name');
+        $this->processor->setDefaultPageSize(3);
+        $itr = $this->processor->processRequest(new Request([]));
+
+        if (! $valid) {
+            self::assertInstanceOf(FormInterface::class, $itr);
+        } else {
+            self::assertInstanceOf(PagerIterator::class, $itr);
+        }
+    }
+
+    public function testContinuationTokenCouldBeDisabled(): void
+    {
+        $formFactory = (new FormFactoryBuilder(true))
+            ->addExtension(new ValidatorExtension((new ValidatorBuilder())->getValidator()))
+            ->addTypeExtension(new FormTypeHttpFoundationExtension(new AutoSubmitRequestHandler()))
+            ->getFormFactory();
+
+        $queryBuilder = self::$entityManager->getConnection()->createQueryBuilder();
+        $queryBuilder
+            ->select('id', 'name', 'nameLength')
+            ->from('user', 'u')
+        ;
+
+        $this->processor = new Processor(
+            $queryBuilder,
+            $formFactory,
+            [
+                'default_order' => 'name, desc',
+                'order_field' => 'order',
+                'continuation_token' => false,
+                'identifiers' => ['id'],
+            ],
+        );
+
+        $this->processor->addColumn('name');
+        $this->processor->setDefaultPageSize(3);
+        $itr = $this->processor->processRequest(new Request([]));
+
+        self::assertInstanceOf(RowIterator::class, $itr);
+    }
+
+    public function testCustomColumnWorks(): void
+    {
+        $this->processor->addColumn('foobar', new class(self::$entityManager) implements ColumnInterface {
+            private EntityManagerInterface $entityManager;
+
+            public function __construct(EntityManagerInterface $entityManager)
+            {
+                $this->entityManager = $entityManager;
+            }
+
+            public function addCondition($queryBuilder, ExpressionInterface $expression): void
+            {
+                $foobar = $this->entityManager->getRepository(FooBar::class)
+                    ->findOneBy(['foobar' => $expression->getValue()]);
+
+                $queryBuilder->andWhere('u.foobar_id = :foobar')
+                    ->setParameter('foobar', $foobar->id);
+            }
+
+            public function getValidationWalker()
+            {
+                return new ValidationWalker();
+            }
+        });
+        $itr = $this->processor->processRequest(new Request(['foobar' => 'foobar_barbar']));
+
+        self::assertInstanceOf(ObjectIteratorInterface::class, $itr);
+        $result = \iterator_to_array($itr);
+
+        self::assertCount(1, $result);
+        self::assertEquals('barbar', $result[0]['name']);
+    }
+}

--- a/tests/QueryLanguage/Walker/DBAL/SqlWalkerTest.php
+++ b/tests/QueryLanguage/Walker/DBAL/SqlWalkerTest.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+
+namespace Fazland\ApiPlatformBundle\Tests\QueryLanguage\Walker\DBAL;
+
+use Doctrine\DBAL\Query\QueryBuilder;
+use Fazland\ApiPlatformBundle\QueryLanguage\Expression\Literal\LiteralExpression;
+use Fazland\ApiPlatformBundle\QueryLanguage\Walker\DBAL\SqlWalker;
+use Fazland\ApiPlatformBundle\Tests\QueryLanguage\Doctrine\ORM\FixturesTrait;
+use PHPUnit\Framework\TestCase;
+
+class SqlWalkerTest extends TestCase
+{
+    use FixturesTrait;
+
+    private SqlWalker $walker;
+    private QueryBuilder $queryBuilder;
+
+    protected function setUp(): void
+    {
+        $connection = self::$entityManager->getConnection();
+        $this->queryBuilder = $connection->createQueryBuilder()
+            ->select('id', 'name')
+            ->from('user', 'u')
+        ;
+
+        $this->walker = new SqlWalker($this->queryBuilder, 'u.name');
+    }
+
+    public function testShouldBuildEqualComparison(): void
+    {
+        $this->queryBuilder->andWhere(
+            $this->walker->walkComparison('=', LiteralExpression::create('foo'))
+        );
+
+        self::assertEquals('SELECT id, name FROM user u WHERE "u"."name" = :u_name', $this->queryBuilder->getSQL());
+        self::assertEquals('foo', $this->queryBuilder->getParameter('u_name'));
+    }
+}

--- a/tests/QueryLanguage/Walker/Doctrine/DqlWalkerTest.php
+++ b/tests/QueryLanguage/Walker/Doctrine/DqlWalkerTest.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Fazland\ApiPlatformBundle\Tests\QueryLanguage\Walker;
+namespace Fazland\ApiPlatformBundle\Tests\QueryLanguage\Walker\Doctrine;
 
 use Doctrine\DBAL\ParameterType;
 use Doctrine\ORM\QueryBuilder;
@@ -16,7 +16,6 @@ class DqlWalkerTest extends TestCase
     use FixturesTrait;
 
     private DqlWalker $walker;
-
     private QueryBuilder $queryBuilder;
 
     protected function setUp(): void


### PR DESCRIPTION
Add "raw" SQL processor based on doctrine DBAL query builder.
It is meant to be used if low-level data retrieval is needed (query a view, use of a custom db extension) or where an ORM should/could not be used.

Comparing to ORM and ODM ones, it has some few limitations:

- There is no auto-mapping of fields, all the selected fields need to be selected with `select` method on query builder prior to the initialization of the Processor
- `$entry` support is limited. Due to the lack of a schema, there's no support to an automatic join mechanism
- To fully support pagination (with continuation token), the SQL built via query builder will be wrapped as a subquery in the `FROM` clause
- Result iterator emits associative arrays instead of objects
- Results are emitted *as emitted from PDO*. No conversion will be made on the returned result.